### PR TITLE
feat: try to get the base url from the PR comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ await pickTestsFromPullRequest(on, config, pullOptions)
 
 ## baseUrl
 
-If the pull request text has a line with just `baseUrl <URL>` the it will be extracted too. This makes it convenient to specify a custom deploy to be tested for this specific pull request.
+If the pull request text OR its comments have a line with just `baseUrl <URL>` the it will be extracted too. This makes it convenient to specify a custom deploy to be tested for this specific pull request.
 
 ```text
 // pull request text
@@ -65,6 +65,15 @@ some test tags
 These tests should be run against this URL
 baseUrl https://preview-1.acme.co
 ```
+
+The base URL is found if it is a single line of text in the pull request body or its comment in one of these formats:
+
+```text
+baseUrl https://preview-1.acme.co
+TestURL: https://preview-1.acme.co
+```
+
+If the URL is present in the body and in several comments, the URL found in the latest comment wins.
 
 **Tip:** you can control if you want to set the baseUrl based on the pull request text using an option
 

--- a/bin/get-pr-body.js
+++ b/bin/get-pr-body.js
@@ -59,7 +59,8 @@ getPullRequestNumber(
 
     return getPullRequestBody(options, envOptions).then((body) => {
       console.log(body)
-      const testsToRun = getTestsToRun(['@log', '@sanity'], body)
+      const prComments = []
+      const testsToRun = getTestsToRun(['@log', '@sanity'], body, prComments)
       console.log('tests to run')
       console.log(testsToRun)
     })

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@
 const debug = require('debug')('grep-tests-from-pull-requests')
 const {
   getPullRequestBody,
+  getPullRequestComments,
   getTestsToRun,
   getPullRequestNumber,
 } = require('./utils')
@@ -60,7 +61,8 @@ async function registerPlugin(on, config, options = {}) {
     }
 
     const prBody = await getPullRequestBody(prOptions, envOptions)
-    const testsToRun = getTestsToRun(options.tags, prBody)
+    const prComments = await getPullRequestComments(prOptions, envOptions)
+    const testsToRun = getTestsToRun(options.tags, prBody, prComments)
     console.log('tests to run', testsToRun)
     if (testsToRun) {
       if (testsToRun.baseUrl) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -107,6 +107,7 @@ async function getPullRequestComments(options, envOptions) {
   })
 
   const comments = JSON.parse(res.body)
+  debug('found %d comments for PR %d', comments.length, options.pull)
   // each comment in the array is an object with a body property
   return comments
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -14,6 +14,25 @@ function validateCommonOptions(options, envOptions) {
   }
 }
 
+/**
+ * Finds and returns the test (base URL) in the given text line, if present.
+ * @param {string} line a single line of text
+ */
+function getBaseUrlFromTextLine(line) {
+  // if the line is in the form of
+  // baseUlr <url>
+  if (line.includes('baseUrl')) {
+    return line.split('baseUrl')[1].trim()
+  }
+  // if the line is in the frm of
+  // Test URL: <url>
+  if (line.match(/^\s*Test URL:/)) {
+    return line.split('Test URL:')[1].trim()
+  }
+
+  // did not find the base url
+}
+
 // assume we do need to authenticate to fetch the pull request body
 async function getPullRequestBody(options, envOptions) {
   if (options.token) {
@@ -48,10 +67,16 @@ async function getPullRequestBody(options, envOptions) {
 }
 
 /**
+ * @typedef {object} PullRequestComment
+ * @property {string} body The text of the comment
+ */
+
+/**
  * Return the list of comments on a specific pull request. The last
  * commit is the latest commit. Each returned comment is an object
  * with "body", and other properties.
  * assume we do need to authenticate to fetch the pull request body
+ * @returns {Promise<PullRequestComment[]>} List of comments.
  */
 async function getPullRequestComments(options, envOptions) {
   if (options.token) {
@@ -93,8 +118,9 @@ function isLineChecked(line) {
 /**
  * @param {string[]} tagsToLookFor String tags to find in the pull request body
  * @param {string} pullRequestBody The pull request text with checkboxes
+ * @param {PullRequestComment[]} pullRequestComments The pull request comments
  */
-function getTestsToRun(tagsToLookFor, pullRequestBody) {
+function getTestsToRun(tagsToLookFor, pullRequestBody, pullRequestComments) {
   const testsToRun = {
     all: false,
     tags: [],
@@ -114,9 +140,7 @@ function getTestsToRun(tagsToLookFor, pullRequestBody) {
       testsToRun.all = true
     }
 
-    if (line.includes('baseUrl')) {
-      testsToRun.baseUrl = line.split('baseUrl')[1].trim()
-    }
+    testsToRun.baseUrl = getBaseUrlFromTextLine(line)
 
     tagsToLookFor.forEach((tag) => {
       if (line.includes(tag) && isLineChecked(line)) {
@@ -124,6 +148,15 @@ function getTestsToRun(tagsToLookFor, pullRequestBody) {
       }
     })
   })
+
+  // pull requests can overwrite the base url
+  pullRequestComments.forEach((comment) => {
+    const commentLines = comment.body.split('\n')
+    commentLines.forEach((line) => {
+      testsToRun.baseUrl = getBaseUrlFromTextLine(line)
+    })
+  })
+
   return testsToRun
 }
 


### PR DESCRIPTION
# Summary

- can find the test url from the PR comments  in the form `baseUrl <URL>` or `Test URL: <URL>`
- the latest URL overwrites the previous URLs
- closes #6 

## Tests to run

Please pick all tests you would like to run against this pull request

- [ ] all tests
- [ ] tests tagged `@sanity`
- [ ] tests tagged `@quick`


