### PR TITLE
feat: find CYPRESS_ env values in the PR text

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,7 +8,7 @@ Please pick all tests you would like to run against this pull request
 - [ ] tests tagged `@sanity`
 - [ ] tests tagged `@quick`
 
-Additional Cypress environment values to pass from this pull request. Cypress should have these values casted correctly and available in `Cypress.env()` object.
+Additional Cypress environment values to pass from this pull request. Cypress should have these values cast correctly and available in `Cypress.env()` object.
 
 CYPRESS_num=1
 CYPRESS_correct=true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,3 +7,14 @@ Please pick all tests you would like to run against this pull request
 - [ ] all tests
 - [ ] tests tagged `@sanity`
 - [ ] tests tagged `@quick`
+
+Additional Cypress environment values to pass from this pull request. Cypress should have these values casted correctly and available in `Cypress.env()` object.
+
+CYPRESS_num=1
+CYPRESS_correct=true
+
+And another value
+
+CYPRESS_FRIENDLY_GREETING=Hello
+
+The 3 above values should be available under `num`, `correct`, and `FRIENDLY_GREETING` names

--- a/README.md
+++ b/README.md
@@ -107,6 +107,18 @@ if (testsToRun) {
 }
 ```
 
+## Additional environment variables
+
+If the pull request has lines that start with `CYPRESS_...=value` then they are automatically are parsed and cast and added to the `Cypress.env` object. For example
+
+```
+CYPRESS_num=1
+CYPRESS_correct=true
+CYPRESS_FRIENDLY_GREETING=Hello
+```
+
+Will add the values `{num: 1, correct: true, FRIENDLY_GREETING: "Hello"}` to the `Cypress.env`
+
 ## Aliases
 
 This package includes several scripts that let you find the pull request body and the test tags and the base URL of a given pull request.

--- a/cypress/integration/utils.js
+++ b/cypress/integration/utils.js
@@ -1,6 +1,12 @@
 /// <reference types="cypress" />
 
-import { getBaseUrlFromTextLine } from '../../src/universal'
+chai.config.truncateThreshold = 200
+
+import {
+  getBaseUrlFromTextLine,
+  getCypressEnvVariable,
+  cast,
+} from '../../src/universal'
 
 describe('getBaseUrlFromTextLine', () => {
   it('finds baseUrl', () => {
@@ -19,5 +25,52 @@ describe('getBaseUrlFromTextLine', () => {
     expect(getBaseUrlFromTextLine('Test URL: http://example.com')).to.eq(
       'http://example.com',
     )
+  })
+})
+
+describe('cast', () => {
+  it('converts numbers', () => {
+    expect(cast('1')).to.eq(1)
+    expect(cast('1.12')).to.eq(1.12)
+  })
+
+  it('converts booleans', () => {
+    expect(cast('true')).to.be.true
+    expect(cast('false')).to.be.false
+  })
+
+  it('leaves strings unchanged', () => {
+    expect(cast('hello there')).to.equal('hello there')
+  })
+})
+
+describe('getCypressEnvVariable', () => {
+  it('finds Cypress string variable', () => {
+    const s = 'CYPRESS_FRIENDLY_GREETING=Hello'
+    expect(getCypressEnvVariable(s)).to.deep.eq({
+      key: 'FRIENDLY_GREETING',
+      value: 'Hello',
+    })
+  })
+
+  it('finds Cypress number variable', () => {
+    const s = 'CYPRESS_num=1'
+    expect(getCypressEnvVariable(s)).to.deep.eq({
+      key: 'num',
+      value: 1,
+    })
+  })
+
+  it('finds Cypress boolean variable', () => {
+    const s = 'CYPRESS_correct=true'
+    expect(getCypressEnvVariable(s)).to.deep.eq({
+      key: 'correct',
+      value: true,
+    })
+  })
+
+  it('returns undefined otherwise', () => {
+    const s = 'hello world'
+    expect(getCypressEnvVariable(s)).to.be.undefined
   })
 })

--- a/src/index.js
+++ b/src/index.js
@@ -90,6 +90,12 @@ async function registerPlugin(on, config, options = {}) {
           delete config.env.grep
           config.env.grepTags = grepTags
         }
+
+        if (Object.keys(testsToRun.env).length) {
+          console.log('found the following env values in the PR text')
+          console.log('%o', testsToRun.env)
+          Object.assign(config.env, testsToRun.env)
+        }
       }
     }
 

--- a/src/universal.js
+++ b/src/universal.js
@@ -17,4 +17,33 @@ function getBaseUrlFromTextLine(line) {
   // did not find the base url
 }
 
-module.exports = { getBaseUrlFromTextLine }
+function cast(str) {
+  if (str === 'true') {
+    return true
+  }
+  if (str === 'false') {
+    return false
+  }
+  const n = Number(str)
+  if (!isNaN(n)) {
+    return n
+  }
+
+  // return the original string
+  return str
+}
+
+function getCypressEnvVariable(line) {
+  if (line.match(/^\s*CYPRESS_/)) {
+    const values = line.split('CYPRESS_')[1].trim()
+    const [key, valueString] = values.split('=')
+    const value = cast(valueString)
+    return {
+      key,
+      value,
+    }
+  }
+  // did not find Cypress variable
+}
+
+module.exports = { getBaseUrlFromTextLine, getCypressEnvVariable, cast }

--- a/src/universal.js
+++ b/src/universal.js
@@ -34,7 +34,7 @@ function cast(str) {
 }
 
 function getCypressEnvVariable(line) {
-  if (line.match(/^\s*CYPRESS_/)) {
+  if (line.match(/^CYPRESS_/)) {
     const values = line.split('CYPRESS_')[1].trim()
     const [key, valueString] = values.split('=')
     const value = cast(valueString)

--- a/src/utils.js
+++ b/src/utils.js
@@ -143,9 +143,9 @@ function getTestsToRun(tagsToLookFor, pullRequestBody, pullRequestComments) {
       testsToRun.baseUrl = foundUrl
     } else {
       const envVariable = getCypressEnvVariable(line)
-      if (envVariable) {
+      if (envVariable && 'key' in envVariable && 'value' in envVariable) {
         debug('found env variable: %s', envVariable)
-        testsToRun.env[envVariable.name] = envVariable.value
+        testsToRun.env[envVariable.key] = envVariable.value
       }
     }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,5 @@
 // @ts-check
-const { getBaseUrlFromTextLine } = require('./universal')
+const { getBaseUrlFromTextLine, getCypressEnvVariable } = require('./universal')
 const got = require('got')
 const debug = require('debug')('grep-tests-from-pull-requests')
 
@@ -120,6 +120,8 @@ function getTestsToRun(tagsToLookFor, pullRequestBody, pullRequestComments) {
     all: false,
     tags: [],
     baseUrl: null,
+    // additional environment variables to set found in the text
+    env: {},
   }
 
   if (!tagsToLookFor || !tagsToLookFor.length) {
@@ -139,6 +141,12 @@ function getTestsToRun(tagsToLookFor, pullRequestBody, pullRequestComments) {
     if (foundUrl) {
       debug('found base url: %s', foundUrl)
       testsToRun.baseUrl = foundUrl
+    } else {
+      const envVariable = getCypressEnvVariable(line)
+      if (envVariable) {
+        debug('found env variable: %s', envVariable)
+        testsToRun.env[envVariable.name] = envVariable.value
+      }
     }
 
     tagsToLookFor.forEach((tag) => {


### PR DESCRIPTION
- closes #11 
# Summary

## Tests to run

Please pick all tests you would like to run against this pull request

- [ ] all tests
- [ ] tests tagged `@sanity`
- [ ] tests tagged `@quick`

Additional Cypress environment values to pass from this pull request. Cypress should have these values cast correctly and available in `Cypress.env()` object.

CYPRESS_num=1
CYPRESS_correct=true

And another value

CYPRESS_FRIENDLY_GREETING=Hello

The 3 above values should be available under `num`, `correct`, and `FRIENDLY_GREETING` names
