### PR TITLE
fix: handle empty string values

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,15 @@ CYPRESS_correct=true
 CYPRESS_FRIENDLY_GREETING=Hello
 ```
 
-Will add the values `{num: 1, correct: true, FRIENDLY_GREETING: "Hello"}` to the `Cypress.env`
+Will add the values `{num: 1, correct: true, FRIENDLY_GREETING: "Hello"}` to the `Cypress.env`. Note: an empty value is converted to `undefined`.
+
+```
+CYPRESS_age=
+# will produce
+{ age: undefined }
+```
+
+If you really want to skip a value, prefix it somehow, like `xCYPRESS_...=value`
 
 ## Aliases
 

--- a/cypress/integration/utils.js
+++ b/cypress/integration/utils.js
@@ -42,6 +42,10 @@ describe('cast', () => {
   it('leaves strings unchanged', () => {
     expect(cast('hello there')).to.equal('hello there')
   })
+
+  it('converts an empty string to undefined', () => {
+    expect(cast('')).to.be.undefined
+  })
 })
 
 describe('getCypressEnvVariable', () => {
@@ -66,6 +70,14 @@ describe('getCypressEnvVariable', () => {
     expect(getCypressEnvVariable(s)).to.deep.eq({
       key: 'correct',
       value: true,
+    })
+  })
+
+  it('returns undefined value', () => {
+    const s = 'CYPRESS_flag='
+    expect(getCypressEnvVariable(s)).to.deep.equal({
+      key: 'flag',
+      value: undefined,
     })
   })
 

--- a/src/universal.js
+++ b/src/universal.js
@@ -18,6 +18,10 @@ function getBaseUrlFromTextLine(line) {
 }
 
 function cast(str) {
+  if (typeof str === 'undefined' || str === '') {
+    return undefined
+  }
+
   if (str === 'true') {
     return true
   }


### PR DESCRIPTION
# Summary

## Tests to run

Please pick all tests you would like to run against this pull request

- [ ] all tests
- [ ] tests tagged `@sanity`
- [ ] tests tagged `@quick`

Additional Cypress environment values to pass from this pull request. Cypress should have these values cast correctly and available in `Cypress.env()` object.

CYPRESS_num=
CYPRESS_correct=true

And another value

CYPRESS_FRIENDLY_GREETING=

The 3 above values should be available under `num`, `correct`, and `FRIENDLY_GREETING` names
