### PR TITLE
feat: add --pr-url parameter to the script

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Print PR URL should run Cypress tests 🖨
         run: |
           if node ./bin/should-pr-run-cypress-tests.js \
-            --pr-url ${{ github.event.html_url }}; then
+            --pr-url ${{ github.event.pull_request.html_url }}; then
             echo "We should run Cypress tests ✅"
           else
             echo "We should skip Cypress tests 😔"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -69,3 +69,14 @@ jobs:
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Print PR URL should run Cypress tests 🖨
+        run: |
+          if node ./bin/should-pr-run-cypress-tests.js \
+            --pr-url ${{ github.event.html_url }}; then
+            echo "We should run Cypress tests ✅"
+          else
+            echo "We should skip Cypress tests 😔"
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -173,6 +173,14 @@ $ echo $?
 # 0 - we need to run the Cypress tests
 ```
 
+**Tip:** you can pass the full GitHub pull request URL instead of passing the individual command line arguments
+
+```
+$ npx should-pr-run-cypress-tests --owner bahmutov --repo todomvc-no-tests-vercel --pull 15
+# is the same as
+$ npx should-pr-run-cypress-tests --pr-url https://github.com/bahmutov/todomvc-tests-circleci/pull/15
+```
+
 ## Debugging
 
 This plugin uses [debug](https://github.com/debug-js/debug#readme) module to output verbose log messages. Run with environment variable `DEBUG=grep-tests-from-pull-requests` to see those logs.

--- a/bin/should-pr-run-cypress-tests.js
+++ b/bin/should-pr-run-cypress-tests.js
@@ -3,13 +3,17 @@
 const debug = require('debug')('grep-tests-from-pull-requests')
 const arg = require('arg')
 const { getPullRequestNumber, getPullRequestBody } = require('../src/utils')
-const { findTestsToRun } = require('../src/universal')
+const { findTestsToRun, parsePullRequestUrl } = require('../src/universal')
 
 const args = arg({
   '--owner': String,
   '--repo': String,
   '--pull': Number,
   '--commit': String,
+  // the full pull request URL like
+  // https://github.com/bahmutov/todomvc-tests-circleci/pull/15
+  // can replace the individual arguments
+  '--pr-url': String,
 
   // aliases
   '-o': '--owner',
@@ -36,6 +40,15 @@ const options = {
   pull: args['--pull'],
   commit: args['--commit'],
 }
+
+if (args['--pr-url']) {
+  const parsed = parsePullRequestUrl(args['--pr-url'])
+  debug('parsed url %s to %o', args['--pr-url'], parsed)
+  if (parsed) {
+    Object.assign(options, parsed)
+  }
+}
+
 const envOptions = {
   token: process.env.GITHUB_TOKEN || process.env.PERSONAL_GH_TOKEN,
 }

--- a/cypress/integration/utils.js
+++ b/cypress/integration/utils.js
@@ -8,6 +8,7 @@ import {
   shouldRunCypressTests,
   cast,
   findTestsToRun,
+  parsePullRequestUrl,
 } from '../../src/universal'
 
 describe('getBaseUrlFromTextLine', () => {
@@ -136,5 +137,24 @@ describe('findTestsToRun', () => {
         tags,
       })
     })
+  })
+})
+
+describe('parsePullRequestUrl', () => {
+  it('parses pull request url', () => {
+    const parsed = parsePullRequestUrl(
+      'https://github.com/bahmutov/todomvc-tests-circleci/pull/15',
+    )
+    expect(parsed).to.deep.equal({
+      owner: 'bahmutov',
+      repo: 'todomvc-tests-circleci',
+      pull: 15,
+    })
+  })
+
+  it('throws for invalid URL', () => {
+    expect(() => {
+      parsePullRequestUrl('github.com/foo/bar')
+    }).to.throw
   })
 })

--- a/src/universal.js
+++ b/src/universal.js
@@ -145,10 +145,28 @@ function isLineChecked(line) {
   return line.includes('[x]')
 }
 
+function parsePullRequestUrl(url) {
+  if (!url.startsWith('https://github.com')) {
+    throw new Error(`invalid url ${url}`)
+  }
+
+  if (!url.includes('/pull/')) {
+    throw new Error(`invalid url without pull ${url}`)
+  }
+
+  const split = url.split('/')
+  return {
+    owner: split[3],
+    repo: split[4],
+    pull: cast(split[6]),
+  }
+}
+
 module.exports = {
   getBaseUrlFromTextLine,
   getCypressEnvVariable,
   cast,
   shouldRunCypressTests,
   findTestsToRun,
+  parsePullRequestUrl,
 }


### PR DESCRIPTION
# Summary

you can pass the full GitHub pull request URL instead of passing the individual command line arguments

```
$ npx should-pr-run-cypress-tests --owner bahmutov --repo todomvc-no-tests-vercel --pull 15
# is the same as
$ npx should-pr-run-cypress-tests --pr-url https://github.com/bahmutov/todomvc-tests-circleci/pull/15
```

## Tests to run

Maybe we should not be running any E2E tests?

- [x] run Cypress tests

Please pick all tests you would like to run against this pull request

- [ ] all tests
- [ ] tests tagged `@sanity`
- [ ] tests tagged `@quick`

Additional Cypress environment values to pass from this pull request. Cypress should have these values cast correctly and available in `Cypress.env()` object.

CYPRESS_num=1
CYPRESS_correct=true

And another value

CYPRESS_FRIENDLY_GREETING=Hello

The 3 above values should be available under `num`, `correct`, and `FRIENDLY_GREETING` names
