### PR TITLE
Get the list of all PRs instead of the closed open ones only

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,8 @@
       "bin": {
         "get-pr-body": "bin/get-pr-body.js",
         "get-pr-comments": "bin/get-pr-comments.js",
-        "get-pr-tests": "bin/get-pr-tests.js"
+        "get-pr-tests": "bin/get-pr-tests.js",
+        "should-pr-run-cypress-tests": "bin/should-pr-run-cypress-tests.js"
       },
       "devDependencies": {
         "cypress": "^9.6.0",

--- a/src/utils.js
+++ b/src/utils.js
@@ -156,7 +156,7 @@ async function getPullRequestForHeadCommit(options, envOptions) {
   }
 
   // https://docs.github.com/en/rest/reference/pulls#list-pull-requests
-  const url = `https://api.github.com/repos/${options.owner}/${options.repo}/pulls`
+  const url = `https://api.github.com/repos/${options.owner}/${options.repo}/pulls?state=all`
   debug('url: %s', url)
 
   // @ts-ignore


### PR DESCRIPTION
# Summary

This way we will be able to use this library for conventional deployments that doesn't use a tool like Vercel, as the deployment generally starts after the PR is merged and closed.

## Tests to run

Maybe we should not be running any E2E tests?

- [x] run Cypress tests

Please pick all tests you would like to run against this pull request

- [x] all tests
- [ ] tests tagged `@sanity`
- [ ] tests tagged `@quick`

Additional Cypress environment values to pass from this pull request. Cypress should have these values cast correctly and available in `Cypress.env()` object.

CYPRESS_num=1
CYPRESS_correct=true

And another value

CYPRESS_FRIENDLY_GREETING=Hello

The 3 above values should be available under `num`, `correct`, and `FRIENDLY_GREETING` names
