### PR TITLE
add condition to run mutually exclusive mobile tags and testsToRun.tags

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,8 @@
       "bin": {
         "get-pr-body": "bin/get-pr-body.js",
         "get-pr-comments": "bin/get-pr-comments.js",
-        "get-pr-tests": "bin/get-pr-tests.js"
+        "get-pr-tests": "bin/get-pr-tests.js",
+        "should-pr-run-cypress-tests": "bin/should-pr-run-cypress-tests.js"
       },
       "devDependencies": {
         "cypress": "^9.6.0",

--- a/src/index.js
+++ b/src/index.js
@@ -84,6 +84,12 @@ async function registerPlugin(on, config, options = {}) {
           console.log('running all tests, removing possible grep options')
           delete config.env.grep
           delete config.env.grepTags
+        }  else if (testsToRun.tags.length && config.env.grepTags.includes('@mobile')) {
+          // if we have passed @mobile tag then we should only run tests that are 
+          // mutually exclusive between @mobile and testsToRun.tags
+          const grepTags = testsToRun.tags.join(',')
+          console.log('grepping by mutulaly exclusive tags "@mobile" and "%s" tags', grepTags)
+          config.env.grepTags.concat(grepTags)
         } else if (testsToRun.tags.length) {
           const grepTags = testsToRun.tags.join(',')
           console.log('grepping by tags "%s"', grepTags)


### PR DESCRIPTION
# Summary
When we run mobile jobs with passed grepTags environment variable, it will be deleted and overwritten if we have other tag tests checked on the PR body. This added condition will run mutually exclusive mobile and checked tests tags.
## Tests to run

Maybe we should not be running any E2E tests?

- [x] run Cypress tests

Please pick all tests you would like to run against this pull request

- [ ] all tests
- [ ] tests tagged `@sanity`
- [ ] tests tagged `@quick`

Additional Cypress environment values to pass from this pull request. Cypress should have these values cast correctly and available in `Cypress.env()` object.

CYPRESS_num=1
CYPRESS_correct=true

And another value

CYPRESS_FRIENDLY_GREETING=Hello

The 3 above values should be available under `num`, `correct`, and `FRIENDLY_GREETING` names
