### PR TITLE
feat: add --tags option

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,11 +5,11 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout 🛎
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Run tests 🧪
         # https://github.com/cypress-io/github-action
-        uses: cypress-io/github-action@v2
+        uses: cypress-io/github-action@v5
         with:
           build: npx @bahmutov/print-env GITHUB
         env:
@@ -18,7 +18,7 @@ jobs:
           PERSONAL_GH_TOKEN: ${{ secrets.PERSONAL_GH_TOKEN }}
 
       - name: Semantic Release 🚀
-        uses: cycjimmy/semantic-release-action@v2
+        uses: cycjimmy/semantic-release-action@v3
         with:
           branch: main
         env:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -21,11 +21,11 @@ jobs:
         run: echo "$GITHUB_CONTEXT"
 
       - name: Checkout 🛎
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Run tests 🧪
         # https://github.com/cypress-io/github-action
-        uses: cypress-io/github-action@v2
+        uses: cypress-io/github-action@v5
         with:
           build: npx @bahmutov/print-env GITHUB
           env: 'pullRequest=${{ github.event.number }}'

--- a/README.md
+++ b/README.md
@@ -163,6 +163,13 @@ Prints all test tags found in the pull request
 $ npx get-pr-tests --owner bahmutov --repo todomvc-no-tests-vercel --pull 12
 ```
 
+You can pass the list of allowed tags
+
+```
+$ npx get-pr-tests --owner bahmutov --repo todomvc-no-tests-vercel --pull 12 \
+  --tags one,two,three
+```
+
 ### should-pr-run-cypress-tests
 
 Tells if the pull request body has a checkbox to run or skip the Cypress tests. If the tests should run, this script exits with code 0. If the PR disables the Cypress tests, it exits with code 1.

--- a/bin/get-pr-tests.js
+++ b/bin/get-pr-tests.js
@@ -7,6 +7,7 @@ const {
   getPullRequestBody,
   getPullRequestComments,
   getTestsToRun,
+  cleanUpTags,
 } = require('../src/utils')
 
 const args = arg({
@@ -14,12 +15,14 @@ const args = arg({
   '--repo': String,
   '--pull': Number,
   '--commit': String,
+  '--tags': String,
 
   // aliases
   '-o': '--owner',
   '-r': '--repo',
   '-p': '--pull',
   '-c': '--commit',
+  '-t': '--tags',
 })
 debug('args: %o', args)
 
@@ -39,6 +42,7 @@ const options = {
   repo: args['--repo'],
   pull: args['--pull'],
   commit: args['--commit'],
+  tags: args['--tags'],
 }
 const envOptions = {
   token: process.env.GITHUB_TOKEN || process.env.PERSONAL_GH_TOKEN,
@@ -60,7 +64,8 @@ getPullRequestNumber(
 
     const body = await getPullRequestBody(options, envOptions)
     const prComments = await getPullRequestComments(options, envOptions)
-    const tags = ['@log', '@sanity']
+    const tags = cleanUpTags(options.tags) || []
+    debug('cleaned up tags %o', tags)
     const testsToRun = getTestsToRun(body, tags, prComments)
     console.log('tests to run')
     console.log(testsToRun)

--- a/src/utils.js
+++ b/src/utils.js
@@ -188,10 +188,16 @@ async function getPullRequestForHeadCommit(options, envOptions) {
   return pullRequests[0].number
 }
 
+function cleanUpTags(tags = '') {
+  const cleanTags = Array.isArray(tags) ? tags : tags.split(',')
+  return cleanTags.map((s) => s.trim()).filter(Boolean)
+}
+
 module.exports = {
   getPullRequestBody,
   getPullRequestComments,
   getTestsToRun,
   getPullRequestForHeadCommit,
   getPullRequestNumber,
+  cleanUpTags,
 }


### PR DESCRIPTION
# Summary

Get PR tests now accepts the allowed list of tags from the command line `--tags` parameter

closes #21 

## Tests to run

Maybe we should not be running any E2E tests?

- [x] run Cypress tests

Please pick all tests you would like to run against this pull request

- [ ] all tests
- [ ] tests tagged `@sanity`
- [ ] tests tagged `@quick`

Additional Cypress environment values to pass from this pull request. Cypress should have these values cast correctly and available in `Cypress.env()` object.

CYPRESS_num=1
CYPRESS_correct=true

And another value

CYPRESS_FRIENDLY_GREETING=Hello

The 3 above values should be available under `num`, `correct`, and `FRIENDLY_GREETING` names
