### PR TITLE
feat: add --all option

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,10 @@ $ npx should-pr-run-cypress-tests --owner bahmutov --repo todomvc-no-tests-verce
 $ npx should-pr-run-cypress-tests --pr-url https://github.com/bahmutov/todomvc-tests-circleci/pull/15
 ```
 
+## Open vs all pull requests
+
+By default this library gets the pull request that is `open`. If you want to fetch the info from a closed pull request, use an option `all`. For example, the bin scripts accept `--all` argument to fetch all pull requests when searching for specific one.
+
 ## Debugging
 
 This plugin uses [debug](https://github.com/debug-js/debug#readme) module to output verbose log messages. Run with environment variable `DEBUG=grep-tests-from-pull-requests` to see those logs.

--- a/bin/get-pr-body.js
+++ b/bin/get-pr-body.js
@@ -13,12 +13,14 @@ const args = arg({
   '--repo': String,
   '--pull': Number,
   '--commit': String,
+  '--all': String,
 
   // aliases
   '-o': '--owner',
   '-r': '--repo',
   '-p': '--pull',
   '-c': '--commit',
+  '-a': '--all',
 })
 debug('args: %o', args)
 
@@ -38,6 +40,7 @@ const options = {
   repo: args['--repo'],
   pull: args['--pull'],
   commit: args['--commit'],
+  all: args['--all'],
 }
 const envOptions = {
   token: process.env.GITHUB_TOKEN || process.env.PERSONAL_GH_TOKEN,
@@ -49,6 +52,7 @@ getPullRequestNumber(
   options.pull,
   options.commit,
   envOptions,
+  options.all,
 )
   .then((testPullRequestNumber) => {
     if (isNaN(testPullRequestNumber)) {

--- a/bin/get-pr-comments.js
+++ b/bin/get-pr-comments.js
@@ -9,12 +9,14 @@ const args = arg({
   '--repo': String,
   '--pull': Number,
   '--commit': String,
+  '--all': String,
 
   // aliases
   '-o': '--owner',
   '-r': '--repo',
   '-p': '--pull',
   '-c': '--commit',
+  '-a': '--all',
 })
 debug('args: %o', args)
 
@@ -34,6 +36,7 @@ const options = {
   repo: args['--repo'],
   pull: args['--pull'],
   commit: args['--commit'],
+  all: args['--all'],
 }
 const envOptions = {
   token: process.env.GITHUB_TOKEN || process.env.PERSONAL_GH_TOKEN,
@@ -45,6 +48,7 @@ getPullRequestNumber(
   options.pull,
   options.commit,
   envOptions,
+  options.all,
 )
   .then((testPullRequestNumber) => {
     if (isNaN(testPullRequestNumber)) {

--- a/bin/get-pr-tests.js
+++ b/bin/get-pr-tests.js
@@ -16,6 +16,7 @@ const args = arg({
   '--pull': Number,
   '--commit': String,
   '--tags': String,
+  '--all': String,
 
   // aliases
   '-o': '--owner',
@@ -23,6 +24,7 @@ const args = arg({
   '-p': '--pull',
   '-c': '--commit',
   '-t': '--tags',
+  '-a': '--all',
 })
 debug('args: %o', args)
 
@@ -43,6 +45,7 @@ const options = {
   pull: args['--pull'],
   commit: args['--commit'],
   tags: args['--tags'],
+  all: args['--all'],
 }
 const envOptions = {
   token: process.env.GITHUB_TOKEN || process.env.PERSONAL_GH_TOKEN,
@@ -54,6 +57,7 @@ getPullRequestNumber(
   options.pull,
   options.commit,
   envOptions,
+  options.all,
 )
   .then(async (testPullRequestNumber) => {
     if (isNaN(testPullRequestNumber)) {

--- a/bin/should-pr-run-cypress-tests.js
+++ b/bin/should-pr-run-cypress-tests.js
@@ -14,12 +14,14 @@ const args = arg({
   // https://github.com/bahmutov/todomvc-tests-circleci/pull/15
   // can replace the individual arguments
   '--pr-url': String,
+  '--all': String,
 
   // aliases
   '-o': '--owner',
   '-r': '--repo',
   '-p': '--pull',
   '-c': '--commit',
+  '-a': '--all',
 })
 debug('args: %o', args)
 
@@ -39,6 +41,7 @@ const options = {
   repo: args['--repo'],
   pull: args['--pull'],
   commit: args['--commit'],
+  all: args['--all'],
 }
 
 if (args['--pr-url']) {
@@ -59,6 +62,7 @@ getPullRequestNumber(
   options.pull,
   options.commit,
   envOptions,
+  options.all,
 )
   .then((testPullRequestNumber) => {
     if (isNaN(testPullRequestNumber)) {

--- a/src/index.js
+++ b/src/index.js
@@ -43,6 +43,7 @@ async function registerPlugin(on, config, options = {}) {
       testPullRequest,
       testCommit,
       envOptions,
+      options.all,
     )
     if (isNaN(testPullRequestNumber)) {
       throw new Error('Could not find the pull request number')

--- a/src/utils.js
+++ b/src/utils.js
@@ -123,6 +123,7 @@ async function getPullRequestNumber(
   testPullRequest,
   commit,
   envOptions,
+  all = false,
 ) {
   if (testPullRequest) {
     debug('known pull request, returning %s', testPullRequest)
@@ -134,7 +135,7 @@ async function getPullRequestNumber(
   }
 
   const number = await getPullRequestForHeadCommit(
-    { owner, repo, commit },
+    { owner, repo, commit, all },
     envOptions,
   )
   return number
@@ -156,7 +157,9 @@ async function getPullRequestForHeadCommit(options, envOptions) {
   }
 
   // https://docs.github.com/en/rest/reference/pulls#list-pull-requests
-  const url = `https://api.github.com/repos/${options.owner}/${options.repo}/pulls?state=all`
+  const url =
+    `https://api.github.com/repos/${options.owner}/${options.repo}/pulls` +
+    (options.all ? '?state=all' : '')
   debug('url: %s', url)
 
   // @ts-ignore


### PR DESCRIPTION
# Summary

- adds `--all` argument to fetch all pull requests when searching for specific one.
- closes #23

## Tests to run

Maybe we should not be running any E2E tests?

- [x] run Cypress tests

Please pick all tests you would like to run against this pull request

- [ ] all tests
- [ ] tests tagged `@sanity`
- [ ] tests tagged `@quick`

Additional Cypress environment values to pass from this pull request. Cypress should have these values cast correctly and available in `Cypress.env()` object.

CYPRESS_num=1
CYPRESS_correct=true

And another value

CYPRESS_FRIENDLY_GREETING=Hello

The 3 above values should be available under `num`, `correct`, and `FRIENDLY_GREETING` names
