### PR TITLE
feat: grab the list of specs to run

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -21,4 +21,13 @@ And another value
 
 CYPRESS_FRIENDLY_GREETING=Hello
 
-The 3 above values should be available under `num`, `correct`, and `FRIENDLY_GREETING` names
+The 3 above values should be available under `num`, `correct`, and `FRIENDLY_GREETING` names.
+
+Here you can specify a list of Cypress specs to run:
+
+Run these Cypress specs too:
+
+- cypress/e2e/spec-b.cy.js
+- `cypress/e2e/**/*.cy.js`
+
+Back ticks are removed.

--- a/README.md
+++ b/README.md
@@ -86,6 +86,17 @@ const pullOptions = {
 await pickTestsFromPullRequest(on, config, pullOptions)
 ```
 
+## additionalSpecs
+
+Sometimes you want to be explicit and run some specs by name or wildcard. Simply add a list of such specs:
+
+    Run these Cypress specs too:
+
+    - `cypress/e2e/spec-b.cy.js`
+    - cypress/e2e/**/*.cy.js
+
+The entire list will be returned in the property `additionalSpecs`. Back ticks will be removed.
+
 ## Resolved value
 
 The function might resolve with an object if the pull request was found. You can check if the user wants to run all the tests, or a list of tags

--- a/cypress/e2e/utils.cy.js
+++ b/cypress/e2e/utils.cy.js
@@ -1,6 +1,6 @@
 /// <reference types="cypress" />
 
-chai.config.truncateThreshold = 200
+chai.config.truncateThreshold = 500
 
 import {
   getBaseUrlFromTextLine,
@@ -181,7 +181,7 @@ describe('findTestsToRun', () => {
         },
         runCypressTests: true,
         tags: [],
-        additionalSpecs: []
+        additionalSpecs: [ 'cypress/e2e/spec-b.cy.js', 'cypress/e2e/**/*.cy.js']
       })
     })
   })

--- a/cypress/e2e/utils.cy.js
+++ b/cypress/e2e/utils.cy.js
@@ -9,6 +9,7 @@ import {
   cast,
   findTestsToRun,
   parsePullRequestUrl,
+  findAdditionalSpecsToRun
 } from '../../src/universal'
 
 describe('getBaseUrlFromTextLine', () => {
@@ -107,6 +108,65 @@ describe('shouldRunCypressTests', () => {
   })
 })
 
+describe('findAdditionalSpecsToRun', () => {
+  it('finds a few lines', () => {
+    const body = `
+      # PR
+
+      Run these Cypress specs too:
+
+      - cypress/e2e/spec-b.cy.js
+    `
+    const specs = findAdditionalSpecsToRun(body)
+    expect(specs).to.deep.equal(['cypress/e2e/spec-b.cy.js'])
+  })
+
+  it('stops after the list', () => {
+    const body = `
+      # PR
+
+      Run these Cypress specs too:
+
+      - cypress/e2e/spec-b.cy.js
+      - cypress/e2e/spec-c.cy.js
+
+      more text here
+    `
+    const specs = findAdditionalSpecsToRun(body)
+    expect(specs).to.deep.equal(['cypress/e2e/spec-b.cy.js', 'cypress/e2e/spec-c.cy.js'])
+  })
+
+  it('allows wildcards', () => {
+    const body = `
+      # PR
+
+      Run these Cypress specs too:
+
+      - cypress/e2e/spec-b.cy.js
+      - cypress/e2e/**.cy.js
+
+      more text here
+    `
+    const specs = findAdditionalSpecsToRun(body)
+    expect(specs).to.deep.equal(['cypress/e2e/spec-b.cy.js', 'cypress/e2e/**.cy.js'])
+  })
+
+  it('removes back ticks', () => {
+    const body = `
+      # PR
+
+      Run these Cypress specs too:
+
+      - \`cypress/e2e/spec-b.cy.js\`
+      - \`cypress/e2e/**.cy.js\`
+
+      more text here
+    `
+    const specs = findAdditionalSpecsToRun(body)
+    expect(specs).to.deep.equal(['cypress/e2e/spec-b.cy.js', 'cypress/e2e/**.cy.js'])
+  })
+})
+
 describe('findTestsToRun', () => {
   it('finds all the information without tags', () => {
     cy.readFile('.github/PULL_REQUEST_TEMPLATE.md').then((body) => {
@@ -121,6 +181,7 @@ describe('findTestsToRun', () => {
         },
         runCypressTests: true,
         tags: [],
+        additionalSpecs: []
       })
     })
   })
@@ -135,6 +196,7 @@ describe('findTestsToRun', () => {
         env: {},
         runCypressTests: true,
         tags,
+        additionalSpecs: ['cypress/e2e/spec-b.cy.js']
       })
     })
   })

--- a/cypress/fixtures/pr-with-tags.md
+++ b/cypress/fixtures/pr-with-tags.md
@@ -11,3 +11,7 @@ Please pick all tests you would like to run against this pull request
 Run the tests against this URL
 
 baseUrl http://localhost:7777
+
+Run these Cypress specs too:
+
+- `cypress/e2e/spec-b.cy.js`

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "lib": ["ES2023"]
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
       "devDependencies": {
         "cypress": "13.12.0",
         "cypress-grep": "^2.13.1",
-        "prettier": "^2.5.1",
+        "prettier": "^3.3.2",
         "semantic-release": "^24.0.0"
       }
     },
@@ -7232,15 +7232,18 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.5.1.tgz",
-      "integrity": "sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.2.tgz",
+      "integrity": "sha512-rAVeHYMcv8ATV5d508CFdn+8/pHPpXeIid1DdrPwXnaAdH7cqjVbpJaT5eq4yRAFU/lsbwYwSF/n5iNrdJHPQA==",
       "dev": true,
       "bin": {
-        "prettier": "bin-prettier.js"
+        "prettier": "bin/prettier.cjs"
       },
       "engines": {
-        "node": ">=10.13.0"
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/pretty-bytes": {
@@ -14147,9 +14150,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.5.1.tgz",
-      "integrity": "sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.2.tgz",
+      "integrity": "sha512-rAVeHYMcv8ATV5d508CFdn+8/pHPpXeIid1DdrPwXnaAdH7cqjVbpJaT5eq4yRAFU/lsbwYwSF/n5iNrdJHPQA==",
       "dev": true
     },
     "pretty-bytes": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "devDependencies": {
     "cypress": "13.12.0",
     "cypress-grep": "^2.13.1",
-    "prettier": "^2.5.1",
+    "prettier": "^3.3.2",
     "semantic-release": "^24.0.0"
   },
   "dependencies": {

--- a/src/universal.js
+++ b/src/universal.js
@@ -77,13 +77,24 @@ function shouldRunCypressTests(line) {
   // if the user wants to run Cypress tests
 }
 
+/**
+ * @typedef {Object} TestsToRun
+ * @property {boolean} all - if true, run all tests
+ * @property {string[]} tags - list of test tags to run
+ * @property {string|null} baseUrl - base URL to use
+ * @property {Object<string, string|number|boolean>} env - additional environment variables to set
+ * @property {boolean} runCypressTests - if true, run Cypress tests. True by default
+*/
+
 function findTestsToRun(pullRequestBody, tagsToLookFor = [], comments = []) {
+  /** @type TestsToRun */
   const testsToRun = {
     all: false,
     tags: [],
     baseUrl: null,
     // additional environment variables to set found in the text
     env: {},
+    runCypressTests: true
   }
 
   const lines = pullRequestBody.split('\n')


### PR DESCRIPTION
# Summary

- closes #25 

## Tests to run

Maybe we should not be running any E2E tests?

- [x] run Cypress tests

Please pick all tests you would like to run against this pull request

- [ ] all tests
- [ ] tests tagged `@sanity`
- [ ] tests tagged `@quick`

Additional Cypress environment values to pass from this pull request. Cypress should have these values cast correctly and available in `Cypress.env()` object.

CYPRESS_num=1
CYPRESS_correct=true

And another value

CYPRESS_FRIENDLY_GREETING=Hello

The 3 above values should be available under `num`, `correct`, and `FRIENDLY_GREETING` names
