### PR TITLE
feat: add pages to test list

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -31,3 +31,8 @@ Run these Cypress specs too:
 - `cypress/e2e/**/*.cy.js`
 
 Back ticks are removed.
+
+Find specs that visit these pages:
+
+- /homepage
+- /checkout/step1

--- a/README.md
+++ b/README.md
@@ -97,6 +97,17 @@ Sometimes you want to be explicit and run some specs by name or wildcard. Simply
 
 The entire list will be returned in the property `additionalSpecs`. Back ticks will be removed.
 
+## pagesToTest
+
+You can pass parts of URLs that the tests should visit if you are using [cypress-visited-urls](https://github.com/bahmutov/cypress-visited-urls) plugin. List the URLs as a list after:
+
+    Find specs that visit these pages:
+
+    - /homepage/u1234
+    - /checkout/step
+
+Then your project can use `cypress-visited-urls` plugin to check which specs visit the list of these URLs
+
 ## Resolved value
 
 The function might resolve with an object if the pull request was found. You can check if the user wants to run all the tests, or a list of tags

--- a/cypress/e2e/utils.cy.js
+++ b/cypress/e2e/utils.cy.js
@@ -272,6 +272,7 @@ describe('findTestsToRun', () => {
         runCypressTests: true,
         tags: [],
         additionalSpecs: ['cypress/e2e/spec-b.cy.js', 'cypress/e2e/**/*.cy.js'],
+        pagesToTest: ['/homepage', '/checkout/step1'],
       })
     })
   })
@@ -285,6 +286,7 @@ describe('findTestsToRun', () => {
         baseUrl: null,
         runCypressTests: true,
         additionalSpecs: [],
+        pagesToTest: [],
         // parses null and undefined values
         env: {
           person: { age: 42 },
@@ -305,6 +307,7 @@ describe('findTestsToRun', () => {
         runCypressTests: true,
         tags,
         additionalSpecs: ['cypress/e2e/spec-b.cy.js'],
+        pagesToTest: [],
       })
     })
   })

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Grabs the test tags to run from the pull request text",
   "main": "src/index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "cypress run",
     "semantic-release": "semantic-release",
     "cy:open": "cypress open"
   },


### PR DESCRIPTION
# Summary

- closes #30 

## Tests to run

Maybe we should not be running any E2E tests?

- [x] run Cypress tests

Please pick all tests you would like to run against this pull request

- [ ] all tests
- [ ] tests tagged `@sanity`
- [ ] tests tagged `@quick`

Additional Cypress environment values to pass from this pull request. Cypress should have these values cast correctly and available in `Cypress.env()` object.

CYPRESS_num=1
CYPRESS_correct=true

And another value

CYPRESS_FRIENDLY_GREETING=Hello

The 3 above values should be available under `num`, `correct`, and `FRIENDLY_GREETING` names.

Here you can specify a list of Cypress specs to run:

Run these Cypress specs too:

- cypress/e2e/spec-b.cy.js
- `cypress/e2e/**/*.cy.js`

Back ticks are removed.
